### PR TITLE
[Ashwin] fix ordering of log in and registration screens

### DIFF
--- a/app/src/main/java/com/example/cs446/ui/pages/login/LoginNavigator.kt
+++ b/app/src/main/java/com/example/cs446/ui/pages/login/LoginNavigator.kt
@@ -17,22 +17,22 @@ fun LoginNavigator(
     NavHost(navController = navController,
         startDestination = LoginActivityDestination.Login.name.lowercase()) {
         composable(LoginActivityDestination.Register.name.lowercase()) {
-            LoginScreen(
-                viewModel = viewModel,
-                onNavigateToRegister = {
-                    navController.navigate(LoginActivityDestination.Register.name.lowercase())
-               },
-                onLoggedIn = onLoggedIn,
-                modifier = Modifier
-            )
-        }
-        composable(LoginActivityDestination.Login.name.lowercase()) {
             RegisterScreen(
                 viewModel = viewModel,
                 onNavigateToLogin = {
                     navController.navigate(LoginActivityDestination.Login.name.lowercase())
                 },
-                onRegistered = onLoggedIn, // automatically log in after registration
+                onRegistered = onLoggedIn,
+                modifier = Modifier
+            )
+        }
+        composable(LoginActivityDestination.Login.name.lowercase()) {
+            LoginScreen(
+                viewModel = viewModel,
+                onNavigateToRegister = {
+                    navController.navigate(LoginActivityDestination.Register.name.lowercase())
+                },
+                onLoggedIn = onLoggedIn,
                 modifier = Modifier
             )
         }


### PR DESCRIPTION
Noticed the default screen was registration, changed it back
<img width="313" alt="Screenshot 2025-06-12 at 7 05 05 PM" src="https://github.com/user-attachments/assets/42bd45b1-9f85-4fac-acc2-202e50b300ac" />
